### PR TITLE
Greater efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,10 @@ This command will produce the following file in the data/dna directory: `dna_seq
 > [!NOTE]
 > Multithreading is supported in the compression step with the -t [num. of threads] option which can significantly make the compression step faster. However, the RLZ parse is slightly different from what you would get if you run with a single thread. The reason is we cannot identify phrases that span where the file was split. Potentially might add an additional thread number of parse entries that would not exist if you ran with a single thread.
 
-> [!NOTE]
-> The compression ratio is quite high in this example. The reason for this is partly due to the similarity between the reference and sequence file. Another reason is due to writing the parse with uint64_t numbers. For small files, using 8 bytes for each number is too large and therefore wasteful. Maybe will change in the future. 
-
 2. To decompress the file, run the following command
 
 ```
-./rlz -r ../data/dna/dna_ref.txt -s ../data/dna/dna_seq.txt -d
+./rlz -r ../data/dna/dna_ref.txt -p ../data/dna/dna_seq.txt.rlz -d
 ```
 This command should produce a file called `dna_seq.txt.out` in the data/dna directory. This is the decompressed sequence file.
 
@@ -112,7 +109,7 @@ This command will produce the following file in the data/english directory: `eng
 2. To decompress the file, run the following command
 
 ```
-./rlz -r ../data/english/english_ref.txt -s ../data/english/english_seq.txt --bit -d
+./rlz -r ../data/english/english_ref.txt -p ../data/english/english_seq.txt.rlz --bit -d
 ```
 This command should produce a file called `english_seq.txt.out` in the data/english directory. This is the decompressed sequence file.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ However, character-level encoding can fail if the reference file does not contai
 do the encoding at the bit-level. Doing the encoding this way prevents the issue that occurs when the sequence contains a character that is not present in the reference.
 However, the parse might be larger than the character-level parse due to encoding the bit representation of the sequence file. The decompression expects that the files were originally ASCII (8 bit) encoded.
 
-The software performs pattern matching with the FM-index by reversing both the sequence and the reference text internally. This approach enables forward matching and determines the length of the forward match. The correct reference position is obtained by applying an involution to the suffix array position retrieved from the FM-index (which is built on the reversed reference text), a constant-time operation. 
+The software performs pattern matching by streaming the sequence file char by char (or bit by bit) against the FM-index of the reversed reference. This approach enables the software to simulate forward matching of the sequence file against the reference. The correct reference positions of the matches are obtained by applying an involution to the suffix array positions retrieved from the FM-index (which is built on the reversed reference text), a constant-time operation. 
 
 ## Algorithm Workflow
 
@@ -19,12 +19,12 @@ Bit-level encoding:
 
 Common steps (for all encoding types):
 
-1. Reverse the reference and sequence files.
+1. Reverse the reference sequence.
 
 2. Build an FM-index from the reversed reference (in bit or character form).
 
-3. Perform reverse matching:
-    Match each character or bit of the reversed sequence against the reversed reference using the FM-index's backward matching capabilities (to simulate forward matching).
+3. Perform "backwards" (forward) match:
+    Match each character or bit of the sequence against the reversed reference using the FM-index's backward matching capabilities (to simulate forward matching).
    
     3a. If a match is found, check if the next character or bit also matches.
    

--- a/include/rlz_algo.h
+++ b/include/rlz_algo.h
@@ -13,44 +13,31 @@
 class RLZ {
     public:
         std::string ref_file;
-        std::string seq_file;
         sdsl::bit_vector ref_bit_array;
-        sdsl::bit_vector seq_bit_array;
 
-        // Single thread
         RLZ(const std::string ref_file);
-        // Multi thread
-        RLZ(const std::string ref_file, const std::string seq_file);
         ~RLZ();
 
-        void stream_compress(const std::string& seq_file);
-        void compress(int threads);
-
-        void stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
-            FM_Wrapper& fm_support,
-            const std::map<char, uint64_t>& occs,
-            const std::string& seq_file,
-            std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse_vec);
+        void compress(int threads, const std::string& seq_file);
 
         void parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
             FM_Wrapper& fm_support,
             const std::map<char, uint64_t>& occs,
-            const sdsl::bit_vector& seq_bit_array,
+            const std::string& seq_file,
             std::vector<std::vector<std::tuple<uint64_t, uint64_t>>>& seq_parse_vec_vec,
             size_t num_bits_to_process,
             size_t loop_iter,
             size_t num_threads);
 
-        void decompress();
+        void decompress(const std::string& parse_file);
         void load_file_to_bit_vector(const std::string& input_file, sdsl::bit_vector& bit_array);
         void load_reverse_file_to_bit_vector(const std::string& input_file, sdsl::bit_vector& bit_array);
         void calculate_occs(std::string content, std::map<char, uint64_t>& occs);
         void serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse, const std::string& seq_file);
-        std::vector<std::tuple<uint64_t, uint64_t>> deserialize();
+        std::vector<std::tuple<uint64_t, uint64_t>> deserialize(const std::string& parse_file);
 
         void bits_to_str(sdsl::bit_vector bit_array, std::string prefix);
-        void print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse);
-        void clean();
+        void print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse, const std::string& seq_file);
 };
 
 #endif  // RLZ_ALGO_H

--- a/include/rlz_algo_char.h
+++ b/include/rlz_algo_char.h
@@ -13,24 +13,12 @@
 class RLZ_CHAR {
     public:
         std::string ref_file;
-        std::string seq_file;
         std::string ref_content;
-        std::string seq_content;
 
-        // Single thread
         RLZ_CHAR(const std::string ref_file);
-        // Mult-thread
-        RLZ_CHAR(const std::string ref_file, const std::string seq_file);
         ~RLZ_CHAR();
 
-        void stream_compress(const std::string& seq_file);
         void compress(int threads, const std::string& seq_file);
-
-        void stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
-            FM_Wrapper& fm_support,
-            const std::map<char, uint64_t>& occs,
-            const std::string& seq_file,
-            std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse_vec);
 
         void parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
             FM_Wrapper& fm_support,
@@ -41,15 +29,14 @@ class RLZ_CHAR {
             size_t loop_iter,
             size_t num_threads);
 
-        void decompress();
+        void decompress(const std::string& parse_file);
         void load_file_to_string(const std::string& input_file, std::string& content);
         void load_reverse_file_to_string(const std::string& input_file, std::string& content);
         void calculate_occs(std::string content, std::map<char, uint64_t>& occs);
         void serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse, const std::string& seq_file);
-        std::vector<std::tuple<uint64_t, uint64_t>> deserialize();
+        std::vector<std::tuple<uint64_t, uint64_t>> deserialize(const std::string& parse_file);
 
-        void print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse);
-        void clean();
+        void print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse, const std::string& seq_file);
 };
 
 #endif  // RLZ_ALGO_CHAR_H

--- a/include/rlz_algo_char.h
+++ b/include/rlz_algo_char.h
@@ -24,7 +24,7 @@ class RLZ_CHAR {
         ~RLZ_CHAR();
 
         void stream_compress(const std::string& seq_file);
-        void compress(int threads);
+        void compress(int threads, const std::string& seq_file);
 
         void stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
             FM_Wrapper& fm_support,
@@ -35,7 +35,7 @@ class RLZ_CHAR {
         void parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
             FM_Wrapper& fm_support,
             const std::map<char, uint64_t>& occs,
-            const std::string& seq_content,
+            const std::string& seq_file,
             std::vector<std::vector<std::tuple<uint64_t, uint64_t>>>& seq_parse_vec_vec,
             size_t num_bits_to_process,
             size_t loop_iter,

--- a/rlz.cpp
+++ b/rlz.cpp
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
             // Load the sequence file into memory
             else
             {
-                RLZ_CHAR main_parser(ref_file, seq_file);
+                RLZ_CHAR main_parser(ref_file);
                 auto sw_parser_elapsed = sw_parser.elapsed();
                 spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
                 spdlog::stopwatch sw_ref;
@@ -195,13 +195,8 @@ int main(int argc, char **argv)
                 main_parser.load_reverse_file_to_string(ref_file, main_parser.ref_content);
                 auto sw_ref_elapsed = sw_ref.elapsed();
                 spdlog::debug("Finished reading file in {:.3} seconds", sw_ref_elapsed.count());
-                spdlog::stopwatch sw_seq;
-                spdlog::debug("Starting to read the sequence file");
-                main_parser.load_reverse_file_to_string(seq_file, main_parser.seq_content);
-                auto sw_seq_elapsed = sw_ref.elapsed();
-                spdlog::debug("Finished reading file in {:.3} seconds", sw_seq_elapsed.count());
                 spdlog::stopwatch sw_compress;
-                main_parser.compress(threads);
+                main_parser.compress(threads, seq_file);
                 auto sw_compress_elapsed = sw_compress.elapsed();
                 spdlog::debug("Compression function finished in {:.3} seconds", sw_compress_elapsed.count());
             }

--- a/rlz.cpp
+++ b/rlz.cpp
@@ -28,10 +28,16 @@ int main(int argc, char **argv)
     app.add_option("-v,--verbosity", verbosity, "Set verbosity level (0 = none, 1 = basic, 2 = detailed)")->default_val(0);
     app.set_version_flag("--version", version);
     app.footer("Example usage:\n"
-           "  Compress: ./rlz -r reference.fasta -s sequence.fasta\n"
-           "  Compress: ./rlz --ref reference.fasta --seq sequence.fasta\n"
-           "  Decompress: ./rlz -r reference.fasta -p sequence.fasta.rlz -d\n"
-           "  Decompress: ./rlz --ref reference.fasta --parse sequence.fasta.rlz --decompress");
+           "  Default:\n"
+           "    Compress: ./rlz -r reference.fasta -s sequence.fasta\n"
+           "    Compress: ./rlz --ref reference.fasta --seq sequence.fasta\n"
+           "    Decompress: ./rlz -r reference.fasta -p sequence.fasta.rlz -d\n"
+           "    Decompress: ./rlz --ref reference.fasta --parse sequence.fasta.rlz --decompress\n"
+           "  Bit-Level:\n"
+           "    Compress: ./rlz -r reference.fasta -s sequence.fasta --bit\n"
+           "    Compress: ./rlz --ref reference.fasta --seq sequence.fasta --bit\n"
+           "    Decompress: ./rlz -r reference.fasta -p sequence.fasta.rlz -d --bit\n"
+           "    Decompress: ./rlz --ref reference.fasta --parse sequence.fasta.rlz --bit --decompress\n");
     app.description("RLZ compression tool");
     CLI11_PARSE(app, argc, argv);
 
@@ -66,7 +72,7 @@ int main(int argc, char **argv)
             spdlog::debug("Starting to decompress the compressed sequence file");
             spdlog::stopwatch sw;
             spdlog::stopwatch sw_parser;
-            RLZ main_parser(ref_file, seq_file);
+            RLZ main_parser(ref_file);
             auto sw_parser_elapsed = sw_parser.elapsed();
             spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
             spdlog::debug("Starting to store the reference file as a bit vector");
@@ -75,7 +81,7 @@ int main(int argc, char **argv)
             auto sw_ref_elapsed = sw_ref.elapsed();
             spdlog::debug("Loaded file in {:.3} seconds", sw_ref_elapsed.count());
             spdlog::stopwatch sw_decompress;
-            main_parser.decompress();
+            main_parser.decompress(parse_file);
             auto sw_decompress_elapsed = sw_decompress.elapsed();
             auto elapsed = sw.elapsed();
             spdlog::debug("Decompression function finished in {:.3} seconds", sw_decompress_elapsed.count());
@@ -102,44 +108,18 @@ int main(int argc, char **argv)
             spdlog::debug("The sequence file provided: {}", seq_file);
             spdlog::stopwatch sw_parser;
             // Stream the sequence file
-            if (threads == 1)
-            {
-                RLZ main_parser(ref_file);
-                auto sw_parser_elapsed = sw_parser.elapsed();
-                spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
-                spdlog::stopwatch sw_ref;
-                spdlog::debug("Starting to store the reference file as a bit vector");
-                main_parser.load_reverse_file_to_bit_vector(ref_file, main_parser.ref_bit_array);
-                auto sw_ref_elapsed = sw_ref.elapsed();
-                spdlog::debug("Loaded file in {:.3} seconds", sw_ref_elapsed.count());
-                spdlog::stopwatch sw_compress;
-                main_parser.stream_compress(seq_file);
-                auto sw_compress_elapsed = sw_compress.elapsed();
-                spdlog::debug("Compression function finished in {:.3} seconds", sw_compress_elapsed.count());
-
-            }
-            // Load the sequence file into memory
-            else
-            {
-                RLZ main_parser(ref_file, seq_file);
-                auto sw_parser_elapsed = sw_parser.elapsed();
-                spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
-                spdlog::stopwatch sw_ref;
-                spdlog::debug("Starting to store the reference file as a bit vector");
-                main_parser.load_reverse_file_to_bit_vector(ref_file, main_parser.ref_bit_array);
-                auto sw_ref_elapsed = sw_ref.elapsed();
-                spdlog::debug("Loaded file in {:.3} seconds", sw_ref_elapsed.count());
-                spdlog::stopwatch sw_seq;
-                spdlog::debug("Starting to store the sequence file as a bit vector");
-                main_parser.load_reverse_file_to_bit_vector(seq_file, main_parser.seq_bit_array);
-                auto sw_seq_elapsed = sw_ref.elapsed();
-                spdlog::debug("Loaded file in {:.3} seconds", sw_seq_elapsed.count());
-                spdlog::stopwatch sw_compress;
-                main_parser.compress(threads);
-                auto sw_compress_elapsed = sw_compress.elapsed();
-                spdlog::debug("Compression function finished in {:.3} seconds", sw_compress_elapsed.count());
-            }
-
+            RLZ main_parser(ref_file);
+            auto sw_parser_elapsed = sw_parser.elapsed();
+            spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
+            spdlog::stopwatch sw_ref;
+            spdlog::debug("Starting to store the reference file as a bit vector");
+            main_parser.load_reverse_file_to_bit_vector(ref_file, main_parser.ref_bit_array);
+            auto sw_ref_elapsed = sw_ref.elapsed();
+            spdlog::debug("Loaded file in {:.3} seconds", sw_ref_elapsed.count());
+            spdlog::stopwatch sw_compress;
+            main_parser.compress(threads, seq_file);
+            auto sw_compress_elapsed = sw_compress.elapsed();
+            spdlog::debug("Compression function finished in {:.3} seconds", sw_compress_elapsed.count());
             auto elapsed = sw.elapsed();
             spdlog::debug("Finished compressing the sequence file");
             spdlog::info("Compressed in {:.3} seconds", elapsed.count());

--- a/rlz.cpp
+++ b/rlz.cpp
@@ -11,6 +11,7 @@ int main(int argc, char **argv)
 
     std::string ref_file;
     std::string seq_file;
+    std::string parse_file;
     bool decompress = false;
     int verbosity = 0;
     bool clean = false;
@@ -19,16 +20,18 @@ int main(int argc, char **argv)
     std::string version = "Version: 1.0.0";
 
     app.add_option("-r,--ref", ref_file, "The reference file to be used for compression")->configurable()->required();
-    app.add_option("-s,--seq", seq_file, "The sequence file to compress")->configurable()->required();
+    app.add_option("-s,--seq", seq_file, "The sequence file to compress")->configurable();
+    app.add_option("-p,--parse", parse_file, "The RLZ parse file to be decompressed.")->configurable();
     app.add_option("-t,--threads", threads, "Number of threads")->configurable();
     app.add_flag("-d,--decompress", decompress, "Decompress the RLZ parse into the original sequence file")->configurable();
     app.add_flag("--bit", bit, "Set if the reference does not contain all the unique sequence characters")->configurable();
     app.add_option("-v,--verbosity", verbosity, "Set verbosity level (0 = none, 1 = basic, 2 = detailed)")->default_val(0);
-    app.add_flag("--clean", clean, "Remove RLZ output files")->configurable();
     app.set_version_flag("--version", version);
     app.footer("Example usage:\n"
+           "  Compress: ./rlz -r reference.fasta -s sequence.fasta\n"
            "  Compress: ./rlz --ref reference.fasta --seq sequence.fasta\n"
-           "  Decompress: ./rlz --decompress --ref reference.fasta --seq sequence.fasta");
+           "  Decompress: ./rlz -r reference.fasta -p sequence.fasta.rlz -d\n"
+           "  Decompress: ./rlz --ref reference.fasta --parse sequence.fasta.rlz --decompress");
     app.description("RLZ compression tool");
     CLI11_PARSE(app, argc, argv);
 
@@ -45,13 +48,21 @@ int main(int argc, char **argv)
         spdlog::error("Set verbosity level to be 0,1,2");
     }
 
-    if (clean) {RLZ main_parser(ref_file, seq_file); main_parser.clean(); return 0;}
-
     if (bit)
     {
         if (decompress)
         {
             spdlog::info("Bit alphabet decompression enabled");
+            if (app.count("-r") == 0){
+                spdlog::error("Please provide the reference file used to compress the RLZ parse with -r or --ref");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
+            if (app.count("-p") == 0){
+                spdlog::error("Please provide the RLZ parse to decompress with -p or --parse");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
             spdlog::debug("Starting to decompress the compressed sequence file");
             spdlog::stopwatch sw;
             spdlog::stopwatch sw_parser;
@@ -75,6 +86,16 @@ int main(int argc, char **argv)
         else
         {
             spdlog::info("Bit alphabet compression enabled");
+            if (app.count("-r") == 0){
+                spdlog::error("Please provide a reference file to compress against with -r or --ref");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
+            if (app.count("-s") == 0){
+                spdlog::error("Please provide a sequence file to compress with -s or --seq");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
             spdlog::debug("Starting to compress the sequence file");
             spdlog::stopwatch sw;
             spdlog::debug("The reference file provided: {}", ref_file);
@@ -140,10 +161,20 @@ int main(int argc, char **argv)
         if (decompress)
         {
             spdlog::info("Original alphabet decompression enabled");
+            if (app.count("-r") == 0){
+                spdlog::error("Please provide the reference file used to compress the RLZ parse with -r or --ref");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
+            if (app.count("-p") == 0){
+                spdlog::error("Please provide the RLZ parse to decompress with -p or --parse");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
             spdlog::debug("Starting to decompress the compressed sequence file");
             spdlog::stopwatch sw;
             spdlog::stopwatch sw_parser;
-            RLZ_CHAR main_parser(ref_file, seq_file);
+            RLZ_CHAR main_parser(ref_file);
             auto sw_parser_elapsed = sw_parser.elapsed();
             spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
             spdlog::debug("Starting to read the reference file");
@@ -152,7 +183,7 @@ int main(int argc, char **argv)
             auto sw_ref_elapsed = sw_ref.elapsed();
             spdlog::debug("Loaded file in {:.3} seconds", sw_ref_elapsed.count());
             spdlog::stopwatch sw_decompress;
-            main_parser.decompress();
+            main_parser.decompress(parse_file);
             auto sw_decompress_elapsed = sw_decompress.elapsed();
             auto elapsed = sw.elapsed();
             spdlog::debug("Decompression function finished in {:.3} seconds", sw_decompress_elapsed.count());
@@ -163,43 +194,34 @@ int main(int argc, char **argv)
         else
         {
             spdlog::info("Original alphabet compression enabled");
+            if (app.count("-r") == 0){
+                spdlog::error("Please provide a reference file to compress against with -r or --ref");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
+            if (app.count("-s") == 0){
+                spdlog::error("Please provide a sequence file to compress  with -s or --seq");
+                std::cout << app.help() << std::endl;
+                return -1;
+            }
             spdlog::debug("Starting to compress the sequence file");
             spdlog::stopwatch sw;
             spdlog::debug("The reference file provided: {}", ref_file);
             spdlog::debug("The sequence file provided: {}", seq_file);
             spdlog::stopwatch sw_parser;
             // Stream the sequence file
-            if (threads == 1)
-            {
-                RLZ_CHAR main_parser(ref_file);
-                auto sw_parser_elapsed = sw_parser.elapsed();
-                spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
-                spdlog::stopwatch sw_ref;
-                spdlog::debug("Starting to read the reference file");
-                main_parser.load_reverse_file_to_string(ref_file, main_parser.ref_content);
-                auto sw_ref_elapsed = sw_ref.elapsed();
-                spdlog::debug("Finished reading file in {:.3} seconds", sw_ref_elapsed.count());
-                spdlog::stopwatch sw_compress;
-                main_parser.stream_compress(seq_file);
-                auto sw_compress_elapsed = sw_compress.elapsed();
-                spdlog::debug("Compression function finished in {:.3} seconds", sw_compress_elapsed.count());
-            }
-            // Load the sequence file into memory
-            else
-            {
-                RLZ_CHAR main_parser(ref_file);
-                auto sw_parser_elapsed = sw_parser.elapsed();
-                spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
-                spdlog::stopwatch sw_ref;
-                spdlog::debug("Starting to read the reference file");
-                main_parser.load_reverse_file_to_string(ref_file, main_parser.ref_content);
-                auto sw_ref_elapsed = sw_ref.elapsed();
-                spdlog::debug("Finished reading file in {:.3} seconds", sw_ref_elapsed.count());
-                spdlog::stopwatch sw_compress;
-                main_parser.compress(threads, seq_file);
-                auto sw_compress_elapsed = sw_compress.elapsed();
-                spdlog::debug("Compression function finished in {:.3} seconds", sw_compress_elapsed.count());
-            }
+            RLZ_CHAR main_parser(ref_file);
+            auto sw_parser_elapsed = sw_parser.elapsed();
+            spdlog::debug("Built main parser in {:.3} seconds", sw_parser_elapsed.count());
+            spdlog::stopwatch sw_ref;
+            spdlog::debug("Starting to read the reference file");
+            main_parser.load_reverse_file_to_string(ref_file, main_parser.ref_content);
+            auto sw_ref_elapsed = sw_ref.elapsed();
+            spdlog::debug("Finished reading file in {:.3} seconds", sw_ref_elapsed.count());
+            spdlog::stopwatch sw_compress;
+            main_parser.compress(threads, seq_file);
+            auto sw_compress_elapsed = sw_compress.elapsed();
+            spdlog::debug("Compression function finished in {:.3} seconds", sw_compress_elapsed.count());
             auto elapsed = sw.elapsed();
             spdlog::debug("Finished compressing the sequence file");
             spdlog::info("Compressed in {:.3} seconds", elapsed.count());

--- a/src/rlz_algo.cpp
+++ b/src/rlz_algo.cpp
@@ -27,17 +27,6 @@ std::chrono::duration<double> serialize_time{0.0};
 RLZ::RLZ(const std::string ref_file): ref_file(ref_file){}
 
 /**
-* @brief Constuctor of RLZ class.
-*
-* Assigns the ref_file and seq_file variables with the file paths
-*
-* @param[in] ref_file [string] Path to reference file 
-* @param[in] seq_file [string] Path to sequence file
-*/
-
-RLZ::RLZ(const std::string ref_file, const std::string seq_file): ref_file(ref_file), seq_file(seq_file){}
-
-/**
 * @brief Destructor of RLZ class.
 *
 * Currently does nothing.
@@ -182,6 +171,8 @@ void RLZ::load_reverse_file_to_bit_vector(const std::string& input_file, sdsl::b
 *
 * @param [in] fm_index [sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>] the fm-index of the reference
 * @param [in] fm_support [FM_Wrapper] Utility object that allows us to do search and locate queries with fm-index.
+* @param [in] occs [const std::map<char, uint64_t>&] The compressed F column of the fm-index
+* @param [in] seq_file [const std::string&] the sequence file
 * @param [in] seq_parse_vec_vec [std::vector<std::vector<std::tuple<uint64_t, uint64_t>>>] empty RLZ parse vectors equal to number of threads
 * @param [in] num_bits_to_process [size_t] the number of bits that should be processed. Useful for the OpenMP parallelization.
 * @param [in] loop_iter [size_t] the loop iteration. Useful for OpenMP and making sure we are thread-safe.
@@ -193,9 +184,9 @@ void RLZ::load_reverse_file_to_bit_vector(const std::string& input_file, sdsl::b
 void RLZ::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
         FM_Wrapper& fm_support,
         const std::map<char, uint64_t>& occs,
-        const sdsl::bit_vector& seq_bit_array,
+        const std::string& seq_file,
         std::vector<std::vector<std::tuple<uint64_t, uint64_t>>>& seq_parse_vec_vec,
-        size_t num_bits_to_process,
+        size_t num_char_to_process,
         size_t loop_iter,
         size_t num_threads)
 {
@@ -204,134 +195,36 @@ void RLZ::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>&
     size_t prev_right = fm_index.bwt.size();
     size_t next_left = 0;
     size_t next_right = fm_index.bwt.size();
-    long long int seq_size = static_cast<long long int>(seq_bit_array.size());
-
-    long long int start_loc = (seq_size - 1) - (loop_iter * num_bits_to_process);
-    long long int end_loc;
-
-    // Last chunk so process remaining bits
-    if (loop_iter == num_threads - 1)
-        end_loc = -1;
-    // Process bits up to next chunk
-    else
-        end_loc = (seq_size - 1) - ((loop_iter + 1) * num_bits_to_process);
-
-    // Process the file in reverse for backwards matching with FM-index.
-    for (long long int i = start_loc; i > end_loc; i--) 
-    {
-        char next_char = seq_bit_array[i] ? '1' : '0';
-
-        pattern_len++;
-
-        std::tuple<size_t,size_t> previous_ranges = std::make_tuple(prev_left, prev_right);
-        auto back_start = std::chrono::high_resolution_clock::now();
-        std::tuple<size_t,size_t> next_ranges = fm_support.backward_match(fm_index, occs, previous_ranges, next_char);
-        auto back_end = std::chrono::high_resolution_clock::now();
-        backward_match_time += back_end - back_start;
-        next_left = std::get<0>(next_ranges);
-        next_right = std::get<1>(next_ranges);
-
-        // If same then that means no perfect match so we reset.
-        if (next_left == next_right){
-            pattern_len--; // -1 due to not matching the last character successfully
-            auto sa_start = std::chrono::high_resolution_clock::now();
-            uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, prev_left);
-            uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos; // 0 based involution formula of sa position to correct for the reverse string matching (will give pos in ref where pattern ends)
-            uint64_t adjusted_sa_pos = mirrored_sa_pos - pattern_len; // adjust the position to where pattern starts
-            auto sa_end = std::chrono::high_resolution_clock::now();
-            sa_time += sa_end - sa_start;
-            seq_parse_vec_vec[loop_iter].emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
-            prev_left = 0;
-            prev_right = fm_index.bwt.size();
-            next_left = 0;
-            next_right = fm_index.bwt.size();
-            pattern_len = 0;
-            ++i;
-        }
-        // If at the end we are still in a perfect match, we save what we have. 
-        else if (i == end_loc + 1)
-        {
-            auto sa_start = std::chrono::high_resolution_clock::now();
-            uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
-            uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos;
-            uint64_t adjusted_sa_pos = mirrored_sa_pos - pattern_len;
-            auto sa_end = std::chrono::high_resolution_clock::now();
-            sa_time += sa_end - sa_start;
-            seq_parse_vec_vec[loop_iter].emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
-        }
-        // Currently in a perfect match
-        else{
-            prev_left = next_left;
-            prev_right = next_right;
-        }
-    }
-}
-
-/**
-* @brief Parses the sequence file in relation to the reference file
-*
-* This function does the RLZ parsing of the sequence file. It currently works at the
-* "psuedo" bit level. To clarify, it currently processes the string representation of the bits of the 
-* sequence file. Working at bit level allows us to compress all types of files.
-*
-* RLZ algorithm tries to greedily find the longest sequence substring match within the reference.
-* The RLZ parse in the end contains (pos, len) pairs
-* in relation to the reference such that the sequence can be reconstructed from only the RLZ parse and the reference
-* file. It is a O(n) algorithm. The size is the reference file + the RLZ parse.
-*
-* The algorithm implemented here is as follows.
-* 1. Starting from the last bit of the reversed sequence file or sequence file chunk, check if bit matches the reversed reference
-* (via backwards match with FM-index) 
-* 2a. If match, check if next bit also matches (ex. 001. I know that 1 matches then check if 01 matches etc...)
-* 2b. If match and end of sequence file or sequence file chunk, push current (pos,len) pair to parse vector
-* 2c. If mismatch, push (prev pos, len - 1) to parse stack. Reset search from bit that caused mismatch.
-*
-* Push to parse stack since we process the string in reverse. Popping from stack gives correct order.
-*
-* @param [in] fm_index [sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>] the fm-index of the reference
-* @param [in] fm_support [FM_Wrapper] Utility object that allows us to do search and locate queries with fm-index.
-* @param [in] occs [std::map<char, uint64_t>] the number of occurences of each bit in the ref file
-* @param [in] seq_file [std::string] the sequence file.
-* @param [in] seq_parse_vec [std::vector<std::tuple<uint64_t, uint64_t>>] empty RLZ parse vectors equal to number of threads
-*
-* @return void
-*/
-
-void RLZ::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
-        FM_Wrapper& fm_support,
-        const std::map<char, uint64_t>& occs,
-        const std::string& seq_file,
-        std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse_vec)
-{
-    uint64_t pattern_len = 0;
-    size_t prev_left = 0;
-    size_t prev_right = fm_index.bwt.size();
-    size_t next_left = 0;
-    size_t next_right = fm_index.bwt.size();
     
-    std::ifstream sfile(seq_file);
+    std::ifstream sfile(seq_file, std::ios::binary | std::ios::ate);
     if (!sfile) {
         spdlog::error("Error opening {}", seq_file);
         std::exit(EXIT_FAILURE);
     }
+    
+    size_t seq_size = static_cast<long long int>(sfile.tellg());
+    size_t start_loc = loop_iter * num_char_to_process;    
 
+    // Move file this many characters
+    sfile.seekg(start_loc, std::ios::beg);
+
+    // Process the file in reverse for backwards matching with FM-index.
     bool retry = false;
     char next_char;
     char byte;
     sdsl::bit_vector seq_bit_array;
     seq_bit_array.resize(8);
-    size_t count = 0; // Keep track of how many bits processed
-
-    // Process the file in reverse for backwards matching with FM-index.
+    size_t count = 0; // Keep track of how many chars processed
     while (sfile)
     {
         if (!retry) {  // Read a new character only if we're not retrying a char
             sfile.get(byte);
             count++;
             if (count % 10000 == 0){
-                spdlog::debug("******** Processed {} bits in sequence file. ********", count * 8);
+                spdlog::debug("******** Thread {}: Processed {} bits in sequence file. ********", loop_iter + 1, count * 8);
             }
             if (sfile.eof()) break; // Exit if end of file
+            if (count == num_char_to_process + 1) break; // Have processed all the characters this thread should process (The +1 because we increment before processing)
             for (int i = 7; i >= 0; --i) {
                 seq_bit_array[7-i] = (byte >> i) & 1; // Here it gets stored in reverse order (0 pos = most sig bit, 1 pos = 2nd most sig bit)
             }
@@ -359,16 +252,16 @@ void RLZ::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 1
                 uint64_t adjusted_sa_pos = mirrored_sa_pos - pattern_len; // adjust the position to where pattern starts
                 auto sa_end = std::chrono::high_resolution_clock::now();
                 sa_time += sa_end - sa_start;
-                seq_parse_vec.emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
+                seq_parse_vec_vec[loop_iter].emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
                 prev_left = 0;
                 prev_right = fm_index.bwt.size();
                 next_left = 0;
                 next_right = fm_index.bwt.size();
                 pattern_len = 0;
-                --i;
+                --i; // Do not increment if no perfect match
             }
             // If at the end we are still in a perfect match, we save what we have. 
-            else if (i == 7 && sfile.peek() == EOF)
+            else if (i == 7 && count == num_char_to_process)
             {
                 auto sa_start = std::chrono::high_resolution_clock::now();
                 uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
@@ -376,7 +269,7 @@ void RLZ::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 1
                 uint64_t adjusted_sa_pos = mirrored_sa_pos - pattern_len;
                 auto sa_end = std::chrono::high_resolution_clock::now();
                 sa_time += sa_end - sa_start;
-                seq_parse_vec.emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
+                seq_parse_vec_vec[loop_iter].emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
             }
             // Currently in a perfect match
             else{
@@ -428,6 +321,7 @@ void RLZ::calculate_occs(std::string content, std::map<char, uint64_t>& occs)
 * stored in a vector in the correct order. The parse at the end is serialized to a file.
 *
 * @param [in] threads [int] The number of threads provided by the user.
+* @param [in] seq_file [const std::string&] The sequence file to compress
 *
 * @return void
 *
@@ -440,7 +334,7 @@ void RLZ::calculate_occs(std::string content, std::map<char, uint64_t>& occs)
 *
 */
 
-void RLZ::compress(int threads)
+void RLZ::compress(int threads, const std::string& seq_file)
 {
     sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32> fm_index;
     std::string binary_reference_text;
@@ -459,19 +353,29 @@ void RLZ::compress(int threads)
 
     FM_Wrapper fm_support;
     
-    // Comment (Testing only)
-    // bits_to_str(seq_bit_array, ".decompress.bits");
-
     std::vector<std::vector<std::tuple<uint64_t, uint64_t>>> seq_parse_vec_vec(threads);
-    size_t num_bits_to_process = seq_bit_array.size() / threads;  // Integer division
 
-    // Comment (Testing only)
-    // bits_to_str(seq_bit_array, ".orig.bits");
+    std::ifstream sfile(seq_file, std::ios::binary | std::ios::ate); // Opens the file in binary mode and moves indicator to end
+    if (!sfile) {
+        spdlog::error("Error opening {}", seq_file);
+        std::exit(EXIT_FAILURE);
+    }
+    size_t seq_size = static_cast<size_t>(sfile.tellg());
+    sfile.close();
 
+    size_t num_char_to_process;
+    if (threads == 1){
+        num_char_to_process = seq_size;
+    }
+    else{
+        num_char_to_process = seq_size / (threads-1);  // Integer division (threads-1 to ensure last thread does not process more chars than num_char_to_process)
+    }
+    spdlog::debug("Each thread will process {} bits", num_char_to_process * 8);
+    
     #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < threads; i++)
     {
-        parse(fm_index, fm_support, occs, seq_bit_array, seq_parse_vec_vec, num_bits_to_process, i, threads);
+        parse(fm_index, fm_support, occs, seq_file, seq_parse_vec_vec, num_char_to_process, i, threads);
     }
 
     spdlog::debug("Total FM-index time (s): {:.6f}", std::chrono::duration<double>(backward_match_time).count());
@@ -491,7 +395,7 @@ void RLZ::compress(int threads)
         }
     }
 
-    spdlog::debug("The sequence was encoded in {} bits", seq_bit_array.size());
+    spdlog::debug("The sequence was encoded in {} bits", seq_size * 8);
     spdlog::debug("The rlz parse encodes for {} bits", bits_stored);
 
     auto serialize_start = std::chrono::high_resolution_clock::now();
@@ -501,97 +405,8 @@ void RLZ::compress(int threads)
     spdlog::debug("Total serialize time (s): {:.6f}", std::chrono::duration<double>(serialize_time).count());
 
     // Comment (Testing only)
-    // print_serialize(seq_parse);
+    // print_serialize(seq_parse, seq_file);
 }
-
-/**
-* @brief Compresses the sequence file in relation to the reference file.
-*
-* Creates a FM-index from the reversed reference bit array which we query using the reversed sequence bit array in order to simulate forward matching.
-* We first convert the reversed reference bit array into its string representation so that we can create the FM-index.
-* We query the index one bit at time from the reversed sequence bit array. When the sequence bit does not have a match, 
-* we add the last matching ref position of the sequence and the length of the match to the parse. Then we 
-* restart the match at the last mismatch position. The parse is ultimately
-* stored in a vector in the correct order. The parse at the end is serialized to a file.
-*
-* We stream the sequence file in this function
-*
-* @param [in] seq_file [std::string] The sequence file
-*
-* @return void
-*
-* @note Supposedly cannot create a FM-index directly from bit array.
-* Have to first convert into the reference bits into their string representation and then create the FM-index.
-* Likely a bottleneck in the code as have to store a bit as a byte. [check if there is a way to build bit level FM-index]
-*
-*/
-
-void RLZ::stream_compress(const std::string& seq_file)
-{
-    sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32> fm_index;
-    std::string binary_reference_text;
-
-    // Convert the reference bit array into its string representation
-    for (size_t i = 0; i < ref_bit_array.size(); ++i) {
-        binary_reference_text += (ref_bit_array[i] ? '1' : '0');
-    }
-
-    // Creates the FM-index
-    construct_im(fm_index, binary_reference_text, 1);
-    spdlog::debug("Finished building the FM-index");
-    std::map<char, uint64_t> occs;
-    calculate_occs(binary_reference_text, occs);
-    spdlog::debug("Finished building compressed F column");
-
-    FM_Wrapper fm_support;
-    
-    // Comment (Testing only)
-    // bits_to_str(seq_bit_array, ".decompress.bits");
-
-    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse_vec;
-
-    // Comment (Testing only)
-    // bits_to_str(seq_bit_array, ".orig.bits");
-
-    stream_parse(fm_index, fm_support, occs, seq_file, seq_parse_vec);
-
-    spdlog::debug("Total FM-index time (s): {:.6f}", std::chrono::duration<double>(backward_match_time).count());
-    spdlog::debug("Total SA time (s): {:.6f}", std::chrono::duration<double>(sa_time).count());
-    
-    // Store tuples of (pos,len) in correct order in vector
-    size_t bits_stored = 0;
-    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse;
-    // Can process the parse vectors sequentially since the first vector contains the parse of the start of the non-reversed sequence.
-    for (int i = 0; i < seq_parse_vec.size(); i++)
-    {
-        bits_stored += std::get<1>(seq_parse_vec[i]);
-        seq_parse.emplace_back(seq_parse_vec[i]);
-        // spdlog::debug("Ref Pos: {}, Len: {}", std::get<0>(seq_parse.back()), std::get<1>(seq_parse.back()));
-    }
-
-    // Get file size of sequence file
-    std::ifstream sfile(seq_file, std::ios::ate);
-    if (!sfile) {
-        spdlog::error("Error opening {}", seq_file);
-        std::exit(EXIT_FAILURE);
-    }
-
-    // Get the file size in bytes
-    std::streamsize sfile_size = sfile.tellg();
-
-    spdlog::debug("The sequence was encoded in {} bits", sfile_size * 8);
-    spdlog::debug("The rlz parse encodes for {} bits", bits_stored);
-
-    auto serialize_start = std::chrono::high_resolution_clock::now();
-    serialize(seq_parse, seq_file);
-    auto serialize_end = std::chrono::high_resolution_clock::now();
-    serialize_time += serialize_end - serialize_start;
-    spdlog::debug("Total serialize time (s): {:.6f}", std::chrono::duration<double>(serialize_time).count());
-
-    // Comment (Testing only)
-    // print_serialize(seq_parse);
-}
-
 
 /**
 * @brief Serializes the parse of the sequence file
@@ -603,6 +418,7 @@ void RLZ::stream_compress(const std::string& seq_file)
 * (uint64_t byte size num of pair) (uint64_t byte size pos) (uint64_t byte size len) (uint64_t byte size pos) (uint64_t byte size len) ...
 *  
 * @param[in] seq_parse [std::vector<std::tuple<uint64_t, uint64_t>>] The parse of the seq <(binary ref pos,len),(binary ref pos,len),(binary ref pos,len)... >
+* @param[in] seq_file [std::string] the sequence file name
 *
 * @return void
 */
@@ -631,14 +447,16 @@ void RLZ::serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse
 * Decompress seq_file_name.rlz into tuple vector <(binary ref pos,len),(binary ref pos,len),(binary ref pos,len)... > . 
 * Return the vector.
 *
+* @param[in] parse_file [const std::string&] The parse filename (with .rlz extension)
+*
 * @return Return the vector.
 */
 
-std::vector<std::tuple<uint64_t, uint64_t>> RLZ::deserialize()
+std::vector<std::tuple<uint64_t, uint64_t>> RLZ::deserialize(const std::string& parse_file)
 {
-    std::ifstream ifs(seq_file + ".rlz", std::ios::binary);
+    std::ifstream ifs(parse_file, std::ios::binary);
     if (!ifs) {
-        spdlog::error("Error opening {}", seq_file + ".rlz");
+        spdlog::error("Error opening {}", parse_file);
         std::exit(EXIT_FAILURE);
     }
     uint64_t size;
@@ -672,12 +490,14 @@ std::vector<std::tuple<uint64_t, uint64_t>> RLZ::deserialize()
 * We read the ref position and length from each tuple in the sequence parse and get the corresponding bits from the reference bit array
 * We then convert the bits into bytes and write the ASCII equivalent to file which sbould be the original sequence file.
 *
+* @param[in] parse_file [const std::string&] The parse filename (with .rlz extension)
+*
 * @warning might have to change int to long long int depending on size
 */
 
-void RLZ::decompress()
+void RLZ::decompress(const std::string& parse_file)
 {
-    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse = deserialize();
+    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse = deserialize(parse_file);
     
     size_t bit_size = 0;
     for (const auto& [pos, len] : seq_parse){
@@ -687,6 +507,7 @@ void RLZ::decompress()
     spdlog::debug("The compessed sequence file had {} bits", bit_size);
 
     // Resize the array to be equal to the number of bits to be stored
+    sdsl::bit_vector seq_bit_array;
     seq_bit_array.resize(bit_size);
 
     // Get the sequence bits from the parse + reference bits
@@ -703,6 +524,10 @@ void RLZ::decompress()
 
     // Comment (Testing only)
     // bits_to_str(seq_bit_array, ".decompress.bits");
+
+    // Remove extension from parse file
+    size_t last_dot = parse_file.find_last_of(".");
+    std::string seq_file = parse_file.substr(0, last_dot);
 
     std::ofstream output_file(seq_file + ".out");
     if (!output_file) {
@@ -761,9 +586,9 @@ void RLZ::bits_to_str(sdsl::bit_vector bit_array, std::string ext)
     spdlog::debug("Number of 0s: {}", b_rank0(bit_array.size()));
     spdlog::debug("^^^^^^^^^^^^^^^^^^^^^^^^^");
 
-    std::ofstream ofs(seq_file + ext);
+    std::ofstream ofs("bits_to_str_debug" + ext);
     if (!ofs) {
-        spdlog::error("Error opening {}", seq_file + ext);
+        spdlog::error("Error opening {}", "bits_to_str_debug" + ext);
         std::exit(EXIT_FAILURE);
     }
     ofs << bitstr;
@@ -777,11 +602,12 @@ void RLZ::bits_to_str(sdsl::bit_vector bit_array, std::string ext)
 * We write the non-binary serialization to a file. Testing purposes only.
 * 
 * @param[in] seq_parse [std::vector<std::tuple<uint64_t, uint64_t>>] The parse of the seq <(binary ref pos,len),(binary ref pos,len),(binary ref pos,len)... >
+* @param[in] seq_file [const std::string&] The sequence filename
 *
 * @return void
 */
 
-void RLZ::print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse)
+void RLZ::print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse, const std::string& seq_file)
 {
     std::ofstream ofs(seq_file + ".readable.rlz");
     if (!ofs) {
@@ -795,32 +621,3 @@ void RLZ::print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq
 
     ofs.close();
 }
-
-
-/**
-* @brief Cleans some intermediate file
-*
-* Removes intermediate files for faster testing
-*
-* @return void
-*/
-
-void RLZ::clean()
-{
-    std::remove((ref_file + ".sdsl").c_str());
-    spdlog::info("Removed {} if it existed", ref_file + ".sdsl");
-    std::remove((seq_file + ".sdsl").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".sdsl");
-    std::remove((seq_file + ".rlz").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".rlz");
-    std::remove((seq_file + ".readable.rlz").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".readable.rlz");
-    std::remove((seq_file + ".orig.bits").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".orig.bits");
-    std::remove((seq_file + ".decompress.bits").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".decompress.bits");
-    std::remove((seq_file + ".out").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".out");
-}
-
-

--- a/src/rlz_algo.cpp
+++ b/src/rlz_algo.cpp
@@ -199,7 +199,7 @@ void RLZ::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>&
         size_t loop_iter,
         size_t num_threads)
 {
-    std::string pattern = "";
+    uint64_t pattern_len = 0;
     size_t prev_left = 0;
     size_t prev_right = fm_index.bwt.size();
     size_t next_left = 0;
@@ -221,7 +221,7 @@ void RLZ::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>&
     {
         char next_char = seq_bit_array[i] ? '1' : '0';
 
-        pattern = next_char + pattern;
+        pattern_len++;
 
         std::tuple<size_t,size_t> previous_ranges = std::make_tuple(prev_left, prev_right);
         auto back_start = std::chrono::high_resolution_clock::now();
@@ -233,7 +233,7 @@ void RLZ::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>&
 
         // If same then that means no perfect match so we reset.
         if (next_left == next_right){
-            uint64_t pattern_len = pattern.size() - 1; // -1 due to not matching the last character successfully
+            pattern_len--; // -1 due to not matching the last character successfully
             auto sa_start = std::chrono::high_resolution_clock::now();
             uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, prev_left);
             uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos; // 0 based involution formula of sa position to correct for the reverse string matching (will give pos in ref where pattern ends)
@@ -245,13 +245,12 @@ void RLZ::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>&
             prev_right = fm_index.bwt.size();
             next_left = 0;
             next_right = fm_index.bwt.size();
-            pattern = "";
+            pattern_len = 0;
             ++i;
         }
         // If at the end we are still in a perfect match, we save what we have. 
         else if (i == end_loc + 1)
         {
-            uint64_t pattern_len = pattern.size();
             auto sa_start = std::chrono::high_resolution_clock::now();
             uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
             uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos;
@@ -304,7 +303,7 @@ void RLZ::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 1
         const std::string& seq_file,
         std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse_vec)
 {
-    std::string pattern = "";
+    uint64_t pattern_len = 0;
     size_t prev_left = 0;
     size_t prev_right = fm_index.bwt.size();
     size_t next_left = 0;
@@ -341,7 +340,7 @@ void RLZ::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 1
         {
             char next_char = seq_bit_array[i] ? '1' : '0';
 
-            pattern = next_char + pattern;
+            pattern_len++;
 
             std::tuple<size_t,size_t> previous_ranges = std::make_tuple(prev_left, prev_right);
             auto back_start = std::chrono::high_resolution_clock::now();
@@ -353,7 +352,7 @@ void RLZ::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 1
 
             // If same then that means no perfect match so we reset.
             if (next_left == next_right){
-                uint64_t pattern_len = pattern.size() - 1; // -1 due to not matching the last character successfully
+                pattern_len--; // -1 due to not matching the last character successfully
                 auto sa_start = std::chrono::high_resolution_clock::now();
                 uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, prev_left);
                 uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos; // 0 based involution formula of sa position to correct for the reverse string matching (will give pos in ref where pattern ends)
@@ -365,13 +364,12 @@ void RLZ::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 1
                 prev_right = fm_index.bwt.size();
                 next_left = 0;
                 next_right = fm_index.bwt.size();
-                pattern = "";
+                pattern_len = 0;
                 --i;
             }
             // If at the end we are still in a perfect match, we save what we have. 
             else if (i == 7 && sfile.peek() == EOF)
             {
-                uint64_t pattern_len = pattern.size();
                 auto sa_start = std::chrono::high_resolution_clock::now();
                 uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
                 uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos;

--- a/src/rlz_algo_char.cpp
+++ b/src/rlz_algo_char.cpp
@@ -27,17 +27,6 @@ std::chrono::duration<double> serialize_time_char{0.0};
 RLZ_CHAR::RLZ_CHAR(const std::string ref_file): ref_file(ref_file){}
 
 /**
-* @brief Constuctor of RLZ_CHAR class.
-*
-* Assigns the ref_file and seq_file variables with the file paths
-*
-* @param[in] ref_file [string] Path to reference file 
-* @param[in] seq_file [string] Path to sequence file
-*/
-
-RLZ_CHAR::RLZ_CHAR(const std::string ref_file, const std::string seq_file): ref_file(ref_file), seq_file(seq_file){}
-
-/**
 * @brief Destructor of RLZ_CHAR class.
 *
 * Currently does nothing.
@@ -173,6 +162,8 @@ void RLZ_CHAR::load_reverse_file_to_string(const std::string& input_file, std::s
 *
 * @param [in] fm_index [sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>] the fm-index of the reference
 * @param [in] fm_support [FM_Wrapper] Utility object that allows us to do search and locate queries with fm-index.
+* @param [in] occs [const std::map<char, uint64_t>&] The compressed F column of the fm-index
+* @param [in] seq_file [const std::string&] the sequence file
 * @param [in] seq_parse_vec_vec [std::vector<std::vector<std::tuple<uint64_t, uint64_t>>>] empty RLZ_CHAR parse vectors equal to number of threads
 * @param [in] num_char_to_process [size_t] the number of chars that should be processed. Useful for the OpenMP parallelization.
 * @param [in] loop_iter [size_t] the loop iteration. Useful for OpenMP and making sure we are thread-safe.
@@ -274,119 +265,6 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
 }
 
 
-/**
-* @brief Parses the sequence file in relation to the reference file
-*
-* This function does the RLZ_CHAR parsing of the sequence file. It parses relative to the original file content of the reference.
-* Fails if there is a character in the sequence that is not present in the reference.
-*
-* RLZ algorithm tries to greedily find the longest sequence substring match within the reference.
-* The RLZ parse in the end contains (pos, len) pairs
-* in relation to the reference such that the sequence can be reconstructed from only the RLZ parse and the reference
-* file. It is a O(n) algorithm. The size is the reference file + the RLZ parse.
-*
-* The algorithm implemented here is as follows.
-* 1. Starting from the last char of the reversed sequence file or sequence file chunk, check if char matches the reversed reference
-* (via backwards match with FM-index) 
-* 2a. If match, check if next char also matches (ex. aab. I know that b matches then check if ab matches etc...)
-* 2b. If match and end of sequence file or sequence file chunk, push current (pos,len) pair to parse vector
-* 2c. If mismatch, push (prev pos, len - 1) to parse stack. Reset search from char that caused mismatch.
-*
-* We stream the sequence file in this function
-*
-* @param [in] fm_index [sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>] the fm-index of the reference
-* @param [in] fm_support [FM_Wrapper] Utility object that allows us to do search and locate queries with fm-index.
-* @param [in] occs [std::map<char, uint64_t>] the number of occurences of each char in the ref file
-* @param [in] seq_file [std::string] the sequence file.
-* @param [in] seq_parse_vec [std::vector<std::tuple<uint64_t, uint64_t>>] empty RLZ_CHAR parse vector
-*
-* @return void
-*/
-
-void RLZ_CHAR::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
-        FM_Wrapper& fm_support,
-        const std::map<char, uint64_t>& occs, 
-        const std::string& seq_file,
-        std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse_vec)
-{
-    uint64_t pattern_len = 0;
-    size_t prev_left = 0;
-    size_t prev_right = fm_index.bwt.size();
-    size_t next_left = 0;
-    size_t next_right = fm_index.bwt.size();
-    
-    std::ifstream sfile(seq_file);
-    if (!sfile) {
-        spdlog::error("Error opening {}", seq_file);
-        std::exit(EXIT_FAILURE);
-    }
-
-    bool retry = false;
-    char next_char;
-    size_t count = 0; // Keep track of how many characters processed
-
-    // Process the file in reverse for backwards matching with FM-index.
-    while (sfile)
-    {
-        if (!retry) {  // Read a new character only if we're not retrying a char
-            sfile.get(next_char);
-            count++;
-            if (count % 10000 == 0){
-                spdlog::debug("******** Processed {} unique chars in sequence file. ********", count);
-            }
-            if (sfile.eof()) break; // Exit if end of file
-        }
-
-        pattern_len++;
-
-        std::tuple<size_t,size_t> previous_ranges = std::make_tuple(prev_left, prev_right);
-        auto back_start = std::chrono::high_resolution_clock::now();
-        std::tuple<size_t,size_t> next_ranges = fm_support.backward_match(fm_index, occs, previous_ranges, next_char);
-        auto back_end = std::chrono::high_resolution_clock::now();
-        backward_match_time_char += back_end - back_start;
-        next_left = std::get<0>(next_ranges);
-        next_right = std::get<1>(next_ranges);
-
-        // If same then that means no perfect match so we reset.
-        if (next_left == next_right){
-            pattern_len--; // -1 due to not matching the last character successfully
-            auto sa_start = std::chrono::high_resolution_clock::now();
-            uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, prev_left);
-            uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos; // 0 based involution formula of sa position to correct for the reverse string matching (will give pos in ref where pattern ends)
-            uint64_t adjusted_sa_pos = mirrored_sa_pos - pattern_len; // adjust the position to where pattern starts
-            auto sa_end = std::chrono::high_resolution_clock::now();
-            sa_time_char += sa_end - sa_start;
-            seq_parse_vec.emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
-            prev_left = 0;
-            prev_right = fm_index.bwt.size();
-            next_left = 0;
-            next_right = fm_index.bwt.size();
-            pattern_len = 0;
-            retry = true;
-        }
-        // If at the end we are still in a perfect match, we save what we have. 
-        else if (sfile.peek() == EOF)
-        {
-            auto sa_start = std::chrono::high_resolution_clock::now();
-            uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
-            uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos;
-            uint64_t adjusted_sa_pos = mirrored_sa_pos - pattern_len;
-            auto sa_end = std::chrono::high_resolution_clock::now();
-            sa_time_char += sa_end - sa_start;
-            seq_parse_vec.emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
-            retry = false;
-        }
-        // Currently in a perfect match
-        else{
-            prev_left = next_left;
-            prev_right = next_right;
-            retry = false;
-        }
-    }
-    sfile.close();
-}
-
-
 /** 
 * @brief Calculates the occurances of each char in the provided text in lexicographical order
 *
@@ -426,6 +304,7 @@ void RLZ_CHAR::calculate_occs(std::string content, std::map<char, uint64_t>& occ
 * stored in a vector in the correct order. The parse at the end is serialized to a file.
 *
 * @param [in] threads [int] The number of threads provided by the user.
+* @param [in] seq_file [const std::string&] The sequence file to compress
 *
 * @return void
 *
@@ -506,87 +385,8 @@ void RLZ_CHAR::compress(int threads, const std::string& seq_file)
     spdlog::debug("Total serialize time (s): {:.6f}", std::chrono::duration<double>(serialize_time_char).count());
 
     // Comment (Testing only)
-    // print_serialize(seq_parse);
+    // print_serialize(seq_parse, seq_file);
 }
-
-
-/**
-* @brief Compresses the sequence file in relation to the reference file.
-*
-* Creates a FM-index from the reversed reference string which we query using the reversed sequence string in order to simulate forward matching.
-* We first create the FM-index from the reveresed string representation of the reference.
-* We query the index one char at time from the reversed sequence string. When the sequence char does not have a match, 
-* we add the last matching ref position of the sequence and the length of the match to the parse. Then we 
-* restart the match at the last mismatch position. The parse is ultimately
-* stored in a vector in the correct order. The parse at the end is serialized to a file.
-*
-* We stream the sequence file in this function
-*
-* @param [in] seq_file [std::string] The sequence file 
-*
-* @return void
-* 
-* @warning Will fail if the sequence file contains a char not present in the reference file
-*
-*/
-
-void RLZ_CHAR::stream_compress(const std::string& seq_file)
-{
-    sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32> fm_index;
-    
-    // Creates the FM-index
-    construct_im(fm_index, ref_content, 1);
-    spdlog::debug("Finished building the FM-index");
-
-    // Get the number of occurances of each char in lexicographical order
-    std::map<char, uint64_t> occs;
-    calculate_occs(ref_content, occs);
-    spdlog::debug("Finished building compressed F column");
-
-    FM_Wrapper fm_support;
-
-    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse_vec;
-
-    stream_parse(fm_index, fm_support, occs, seq_file, seq_parse_vec);
-    
-    spdlog::debug("Total FM-index time (s): {:.6f}", std::chrono::duration<double>(backward_match_time_char).count());
-    spdlog::debug("Total SA time (s): {:.6f}", std::chrono::duration<double>(sa_time_char).count());
-
-    // Store tuples of (pos,len) in correct order in vector
-    size_t chars_stored = 0;
-    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse;
-    // Can process the parse vectors sequentially since the first vector contains the parse of the start of the non-reversed sequence.
-    for (int i = 0; i < seq_parse_vec.size(); i++)
-    {
-        chars_stored += std::get<1>(seq_parse_vec[i]);
-        seq_parse.emplace_back(seq_parse_vec[i]);
-        // spdlog::debug("Ref Pos: {}, Len: {}", std::get<0>(seq_parse.back()), std::get<1>(seq_parse.back()));
-    }
-    
-    // Get file size of sequence file
-    std::ifstream sfile(seq_file, std::ios::ate);
-    if (!sfile) {
-        spdlog::error("Error opening {}", seq_file);
-        std::exit(EXIT_FAILURE);
-    }
-
-    // Get the file size in bytes
-    std::streamsize sfile_size = sfile.tellg();
-    sfile.close();    
-
-    spdlog::debug("The sequence was encoded in {} chars", sfile_size);
-    spdlog::debug("The rlz parse encodes for {} chars", chars_stored);
-
-    auto serialize_start = std::chrono::high_resolution_clock::now();
-    serialize(seq_parse, seq_file);
-    auto serialize_end = std::chrono::high_resolution_clock::now();
-    serialize_time_char += serialize_end - serialize_start;
-    spdlog::debug("Total serialize time (s): {:.6f}", std::chrono::duration<double>(serialize_time_char).count());
-
-    // Comment (Testing only)
-    // print_serialize(seq_parse);
-}
-
 
 /**
 * @brief Serializes the parse of the sequence file
@@ -626,15 +426,17 @@ void RLZ_CHAR::serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_
 *
 * Decompress seq_file_name.rlz into tuple vector <(ref pos,len),(ref pos,len),(ref pos,len)... > . 
 * Return the vector.
+* 
+* @param[in] parse_file [const std::string&] The parse filename (with .rlz extension)
 *
 * @return Return the vector.
 */
 
-std::vector<std::tuple<uint64_t, uint64_t>> RLZ_CHAR::deserialize()
+std::vector<std::tuple<uint64_t, uint64_t>> RLZ_CHAR::deserialize(const std::string& parse_file)
 {
-    std::ifstream ifs(seq_file + ".rlz", std::ios::binary);
+    std::ifstream ifs(parse_file, std::ios::binary);
     if (!ifs) {
-        spdlog::error("Error opening {}", seq_file + ".rlz");
+        spdlog::error("Error opening {}", parse_file);
         std::exit(EXIT_FAILURE);
     }
     uint64_t size;
@@ -667,12 +469,14 @@ std::vector<std::tuple<uint64_t, uint64_t>> RLZ_CHAR::deserialize()
 * The sequence parse contains tuples (ref pos, size) that can reconstruct the sequence file given the reference.
 * We read the ref position and length from each tuple in the sequence parse and get the corresponding chars from the reference to reconstruct the sequence
 *
+* @param[in] parse_file [const std::string&] The parse filename (with .rlz extension)
+*
 * @warning might have to change int to long long int depending on size
 */
 
-void RLZ_CHAR::decompress()
+void RLZ_CHAR::decompress(const std::string& parse_file)
 {
-    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse = deserialize();
+    std::vector<std::tuple<uint64_t, uint64_t>> seq_parse = deserialize(parse_file);
     
     size_t char_size = 0;
     for (const auto& [pos, len] : seq_parse){
@@ -682,6 +486,7 @@ void RLZ_CHAR::decompress()
     spdlog::debug("The compessed sequence file had {} chars", char_size);
 
     // Resize the array to be equal to the number of bits to be stored
+    std::string seq_content;
     seq_content.resize(char_size);
 
     // Get the sequence chars from the parse + reference chars
@@ -699,6 +504,10 @@ void RLZ_CHAR::decompress()
     // Comment (Testing only)
     // bits_to_str(seq_bit_array, ".decompress.bits");
 
+    // Remove extension from parse file
+    size_t last_dot = parse_file.find_last_of(".");
+    std::string seq_file = parse_file.substr(0, last_dot);
+    
     std::ofstream output_file(seq_file + ".out");
     if (!output_file) {
         spdlog::error("Error opening {}", seq_file + ".out");
@@ -717,11 +526,12 @@ void RLZ_CHAR::decompress()
 * We write the non-binary serialization to a file. Testing purposes only.
 * 
 * @param[in] seq_parse [std::vector<std::tuple<uint64_t, uint64_t>>] The parse of the seq <(binary ref pos,len),(binary ref pos,len),(binary ref pos,len)... >
+* @param[in] seq_file [const std::string&] The sequence filename
 *
 * @return void
 */
 
-void RLZ_CHAR::print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse)
+void RLZ_CHAR::print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse, const std::string& seq_file)
 {
     std::ofstream ofs(seq_file + ".readable.rlz");
     if (!ofs) {
@@ -734,33 +544,6 @@ void RLZ_CHAR::print_serialize(const std::vector<std::tuple<uint64_t, uint64_t>>
     }
 
     ofs.close();
-}
-
-
-/**
-* @brief Cleans some intermediate file
-*
-* Removes intermediate files for faster testing
-*
-* @return void
-*/
-
-void RLZ_CHAR::clean()
-{
-    std::remove((ref_file + ".sdsl").c_str());
-    spdlog::info("Removed {} if it existed", ref_file + ".sdsl");
-    std::remove((seq_file + ".sdsl").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".sdsl");
-    std::remove((seq_file + ".rlz").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".rlz");
-    std::remove((seq_file + ".readable.rlz").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".readable.rlz");
-    std::remove((seq_file + ".orig.bits").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".orig.bits");
-    std::remove((seq_file + ".decompress.bits").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".decompress.bits");
-    std::remove((seq_file + ".out").c_str());
-    spdlog::info("Removed {} if it existed", seq_file + ".out");
 }
 
 

--- a/src/rlz_algo_char.cpp
+++ b/src/rlz_algo_char.cpp
@@ -184,7 +184,7 @@ void RLZ_CHAR::load_reverse_file_to_string(const std::string& input_file, std::s
 void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32>& fm_index,
         FM_Wrapper& fm_support,
         const std::map<char, uint64_t>& occs, 
-        const std::string& seq_content,
+        const std::string& seq_file,
         std::vector<std::vector<std::tuple<uint64_t, uint64_t>>>& seq_parse_vec_vec,
         size_t num_char_to_process,
         size_t loop_iter,
@@ -195,22 +195,34 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
     size_t prev_right = fm_index.bwt.size();
     size_t next_left = 0;
     size_t next_right = fm_index.bwt.size();
-    long long int seq_size = static_cast<long long int>(seq_content.size());
 
-    long long int start_loc = (seq_size - 1) - (loop_iter * num_char_to_process);
-    long long int end_loc;
+    std::ifstream sfile(seq_file, std::ios::binary | std::ios::ate);
+    if (!sfile) {
+        spdlog::error("Error opening {}", seq_file);
+        std::exit(EXIT_FAILURE);
+    }
+    
+    size_t seq_size = static_cast<long long int>(sfile.tellg());
+    size_t start_loc = loop_iter * num_char_to_process;
 
-    // Last chunk so process remaining chars
-    if (loop_iter == num_threads - 1)
-        end_loc = -1;
-    // Process chars up to next chunk
-    else
-        end_loc = (seq_size - 1) - ((loop_iter + 1) * num_char_to_process);
-
+    // Move file this many characters
+    sfile.seekg(start_loc, std::ios::beg);
+    
     // Process the file in reverse for backwards matching with FM-index.
-    for (long long int i = start_loc; i > end_loc; i--) 
+    bool retry = false;
+    char next_char;
+    size_t count = 0; // Keep track of how many characters processed
+    while (sfile)
     {
-        char next_char = seq_content[i];
+        if (!retry) {  // Read a new character only if we're not retrying a char
+            sfile.get(next_char);
+            count++;
+            if (count % 10000 == 0){
+                spdlog::debug("******** Thread {}: Processed {} unique chars in sequence file. ********", loop_iter + 1, count);
+            }
+            if (sfile.eof()) break; // Exit if end of file
+            if (count == num_char_to_process + 1) break; // Have processed all the characters this thread should process (The +1 because we increment before processing)
+        }
 
         pattern_len++;
 
@@ -237,10 +249,10 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
             next_left = 0;
             next_right = fm_index.bwt.size();
             pattern_len = 0;
-            ++i;
+            retry = true;
         }
         // If at the end we are still in a perfect match, we save what we have. 
-        else if (i == end_loc + 1)
+        else if (sfile.peek() == EOF || count == num_char_to_process)
         {
             auto sa_start = std::chrono::high_resolution_clock::now();
             uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
@@ -249,13 +261,16 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
             auto sa_end = std::chrono::high_resolution_clock::now();
             sa_time_char += sa_end - sa_start;
             seq_parse_vec_vec[loop_iter].emplace_back(std::make_tuple(adjusted_sa_pos, pattern_len));
+            retry = false;
         }
         // Currently in a perfect match
         else{
             prev_left = next_left;
             prev_right = next_right;
+            retry = false;
         }
     }
+    sfile.close();
 }
 
 
@@ -421,7 +436,7 @@ void RLZ_CHAR::calculate_occs(std::string content, std::map<char, uint64_t>& occ
 *
 */
 
-void RLZ_CHAR::compress(int threads)
+void RLZ_CHAR::compress(int threads, const std::string& seq_file)
 {
     sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16, 32> fm_index;
     
@@ -437,7 +452,23 @@ void RLZ_CHAR::compress(int threads)
     FM_Wrapper fm_support;
 
     std::vector<std::vector<std::tuple<uint64_t, uint64_t>>> seq_parse_vec_vec(threads);
-    size_t num_char_to_process = seq_content.size() / threads;  // Integer division
+
+    std::ifstream sfile(seq_file, std::ios::binary | std::ios::ate); // Opens the file in binary mode and moves indicator to end
+    if (!sfile) {
+        spdlog::error("Error opening {}", seq_file);
+        std::exit(EXIT_FAILURE);
+    }
+    size_t seq_size = static_cast<size_t>(sfile.tellg());
+    sfile.close();
+
+    size_t num_char_to_process;
+    if (threads == 1){
+        num_char_to_process = seq_size;
+    }
+    else{
+        num_char_to_process = seq_size / (threads-1);  // Integer division
+    }
+    spdlog::debug("Each thread will process {} characters", num_char_to_process);
 
     // Comment (Testing only)
     // bits_to_str(seq_bit_array, ".orig.bits");
@@ -445,7 +476,7 @@ void RLZ_CHAR::compress(int threads)
     #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < threads; i++)
     {
-        parse(fm_index, fm_support, occs, seq_content, seq_parse_vec_vec, num_char_to_process, i, threads);
+        parse(fm_index, fm_support, occs, seq_file, seq_parse_vec_vec, num_char_to_process, i, threads);
     }
 
     spdlog::debug("Total FM-index time (s): {:.6f}", std::chrono::duration<double>(backward_match_time_char).count());
@@ -465,7 +496,7 @@ void RLZ_CHAR::compress(int threads)
         }
     }
 
-    spdlog::debug("The sequence was encoded in {} chars", seq_content.size());
+    spdlog::debug("The sequence was encoded in {} chars", seq_size);
     spdlog::debug("The rlz parse encodes for {} chars", chars_stored);
 
     auto serialize_start = std::chrono::high_resolution_clock::now();

--- a/src/rlz_algo_char.cpp
+++ b/src/rlz_algo_char.cpp
@@ -190,7 +190,7 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
         size_t loop_iter,
         size_t num_threads)
 {
-    std::string pattern = "";
+    uint64_t pattern_len = 0;
     size_t prev_left = 0;
     size_t prev_right = fm_index.bwt.size();
     size_t next_left = 0;
@@ -212,7 +212,7 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
     {
         char next_char = seq_content[i];
 
-        pattern = next_char + pattern;
+        pattern_len++;
 
         std::tuple<size_t,size_t> previous_ranges = std::make_tuple(prev_left, prev_right);
         auto back_start = std::chrono::high_resolution_clock::now();
@@ -224,7 +224,7 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
 
         // If same then that means no perfect match so we reset.
         if (next_left == next_right){
-            uint64_t pattern_len = pattern.size() - 1; // -1 due to not matching the last character successfully
+            pattern_len--; // -1 due to not matching the last character successfully
             auto sa_start = std::chrono::high_resolution_clock::now();
             uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, prev_left);
             uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos; // 0 based involution formula of sa position to correct for the reverse string matching (will give pos in ref where pattern ends)
@@ -236,13 +236,12 @@ void RLZ_CHAR::parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15>>, 16,
             prev_right = fm_index.bwt.size();
             next_left = 0;
             next_right = fm_index.bwt.size();
-            pattern = "";
+            pattern_len = 0;
             ++i;
         }
         // If at the end we are still in a perfect match, we save what we have. 
         else if (i == end_loc + 1)
         {
-            uint64_t pattern_len = pattern.size();
             auto sa_start = std::chrono::high_resolution_clock::now();
             uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
             uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos;
@@ -295,7 +294,7 @@ void RLZ_CHAR::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15
         const std::string& seq_file,
         std::vector<std::tuple<uint64_t, uint64_t>>& seq_parse_vec)
 {
-    std::string pattern = "";
+    uint64_t pattern_len = 0;
     size_t prev_left = 0;
     size_t prev_right = fm_index.bwt.size();
     size_t next_left = 0;
@@ -323,7 +322,7 @@ void RLZ_CHAR::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15
             if (sfile.eof()) break; // Exit if end of file
         }
 
-        pattern = next_char + pattern;
+        pattern_len++;
 
         std::tuple<size_t,size_t> previous_ranges = std::make_tuple(prev_left, prev_right);
         auto back_start = std::chrono::high_resolution_clock::now();
@@ -335,7 +334,7 @@ void RLZ_CHAR::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15
 
         // If same then that means no perfect match so we reset.
         if (next_left == next_right){
-            uint64_t pattern_len = pattern.size() - 1; // -1 due to not matching the last character successfully
+            pattern_len--; // -1 due to not matching the last character successfully
             auto sa_start = std::chrono::high_resolution_clock::now();
             uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, prev_left);
             uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos; // 0 based involution formula of sa position to correct for the reverse string matching (will give pos in ref where pattern ends)
@@ -347,13 +346,12 @@ void RLZ_CHAR::stream_parse(const sdsl::csa_wt<sdsl::wt_huff<sdsl::rrr_vector<15
             prev_right = fm_index.bwt.size();
             next_left = 0;
             next_right = fm_index.bwt.size();
-            pattern = "";
+            pattern_len = 0;
             retry = true;
         }
         // If at the end we are still in a perfect match, we save what we have. 
         else if (sfile.peek() == EOF)
         {
-            uint64_t pattern_len = pattern.size();
             auto sa_start = std::chrono::high_resolution_clock::now();
             uint64_t sa_pos = fm_support.get_suffix_array_value(fm_index, next_left);
             uint64_t mirrored_sa_pos = fm_index.bwt.size() - 1 - sa_pos;


### PR DESCRIPTION
1. Only keep track of length of pattern and not pattern itself during matching step.
2. Make multithreading streaming 
3. Change how to call decompression
4. Code cleanup